### PR TITLE
cordova android pass password on pdf open

### DIFF
--- a/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
+++ b/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
@@ -52,6 +52,8 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
     private static final int ARG_DOCUMENT_URI = 0;
     private static final int ARG_OPTIONS = 1;
 
+    private String secret;
+
     @Override public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
 
@@ -170,6 +172,8 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
                     else throw new IllegalArgumentException(String.format("Invalid search type: %s", value));
                 } else if ("autosaveEnabled".equals(option)) {
                     builder.autosaveEnabled(options.getBoolean("autosaveEnabled"));
+                } else if ("secret".equals(option)) {
+                    secret =  options.getString("secret");
                 } else if ("annotationEditing".equals(option)) {
                     final JSONObject annotationEditing = options.getJSONObject("annotationEditing");
                     final Iterator<String> annotationOptionIterator = annotationEditing.keys();
@@ -241,6 +245,6 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
     }
 
     private void showDocumentForUri(@NonNull Uri uri, @NonNull final PdfActivityConfiguration configuration) {
-        PdfActivity.showDocument(cordova.getActivity(), uri, configuration);
+        PdfActivity.showDocument(cordova.getActivity(), uri, secret,configuration);
     }
 }

--- a/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
+++ b/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
@@ -52,6 +52,7 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
     private static final int ARG_DOCUMENT_URI = 0;
     private static final int ARG_OPTIONS = 1;
 
+
     private String secret;
 
     @Override public void initialize(CordovaInterface cordova, CordovaWebView webView) {
@@ -219,8 +220,14 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
 
     private void showDocument(@NonNull Uri documentUri, @NonNull final PdfActivityConfiguration configuration,
                               @NonNull final CallbackContext callbackContext) {
-        showDocumentForUri(documentUri, configuration);
-        callbackContext.success();
+        if(secret == null){
+            showDocumentForUri(documentUri, configuration);
+            callbackContext.success();
+        }else{
+            showDocumentForUriWithSecret(documentUri, configuration);
+            callbackContext.success();
+        }
+
     }
 
     /**
@@ -245,6 +252,10 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
     }
 
     private void showDocumentForUri(@NonNull Uri uri, @NonNull final PdfActivityConfiguration configuration) {
+        PdfActivity.showDocument(cordova.getActivity(), uri, configuration);
+    }
+
+    private void showDocumentForUriWithSecret(@NonNull Uri uri, @NonNull final PdfActivityConfiguration configuration) {
         PdfActivity.showDocument(cordova.getActivity(), uri, secret,configuration);
     }
 }


### PR DESCRIPTION
## Resolves #19 

cordova android pass password on pdf open.
I have added few lines on PSPDFKitCordovaPlugin.java. Which accept a 'secret' key from javascript and pass it onto the java function.
I tried it successfully.