### PR TITLE
Fix for default license key being generated on each build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-android",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Integration of the PSPDFKit for Android library.",
   "cordova": {
     "id": "pspdfkit-cordova-android",

--- a/plugin.xml
+++ b/plugin.xml
@@ -11,7 +11,7 @@
   ~   UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
   ~   This notice may not be removed from this file.
 -->
-<plugin id="pspdfkit-cordova-android" version="4.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0"
+<plugin id="pspdfkit-cordova-android" version="4.2.0" xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
     <name>PSPDFKit-Android</name>
     <description>Integration of the PSPDFKit for Android library.</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -55,7 +55,6 @@ You're almost set up for using PSPDFKit-Android for Apache Cordova! Two more ste
         </config-file>
 
         <config-file parent="/*/application" target="AndroidManifest.xml" after="activity">
-            <meta-data android:name="pspdfkit_license_key" android:value="LICENSE_KEY_GOES_HERE" />
             <activity android:name="com.pspdfkit.ui.PdfActivity"
                       android:theme="@style/PSPDFKit.Theme"
                       android:windowSoftInputMode="adjustNothing"/>


### PR DESCRIPTION
This PR fixes an issue where line: 
```xml
<meta-data android:name="pspdfkit_license_key" android:value="LICENSE_KEY_GOES_HERE" />
```
was being added to `AndroidManifest.xml` on each build. This lead to build failures due to duplicated elements in the manifest.