### PR TITLE
Update plugin for Cordova 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Set the minimum SDK version of your Android application to 19. To do so, add the
         <!-- more Android platform settings -->
     </platform>
 
-Configure your PSPDFKit license key inside the `platforms/android/AndroidManifest` (demo license key also works):
+Configure your PSPDFKit license key inside the `platforms/android/app/src/main/AndroidManifest.xml` (demo license key also works):
 
 	<manifest>
 		<application>
@@ -124,6 +124,5 @@ You are now ready to build your app!
 	$ cordova build
 
  ## Contributing
-  
+
  Please ensure [you signed our CLA](https://pspdfkit.com/guides/web/current/miscellaneous/contributing/) so we can accept your contributions.
- 

--- a/package.json
+++ b/package.json
@@ -19,12 +19,11 @@
     "ecosystem:cordova",
     "cordova-android"
   ],
-  "engines": [
-    {
-      "name": "cordova-android",
-      "version": ">=6.3.0"
-    }
-  ],
+  "engines": {
+      "cordovaDependencies": {
+        "4.2.1": { "cordova-android": ">=7.0.0" }
+      }
+  },
   "author": "PSPDFKit",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-android",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Integration of the PSPDFKit for Android library.",
   "cordova": {
     "id": "pspdfkit-cordova-android",

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,10 +26,6 @@ You're almost set up for using PSPDFKit-Android for Apache Cordova! Two more ste
   2) Add your PSPDFKit license key to the <meta-data name="pspdfkit_license_key"> tag of your AndroidManifest.xml.
 ]]></info>
 
-    <engines>
-        <engine name="cordova-android" version=">=6.3.0"/>
-    </engines>
-
     <js-module name="PSPDFKit" src="www/PSPDFKit.js">
         <clobbers target="PSPDFKit"/>
     </js-module>

--- a/plugin.xml
+++ b/plugin.xml
@@ -11,7 +11,7 @@
   ~   UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
   ~   This notice may not be removed from this file.
 -->
-<plugin id="pspdfkit-cordova-android" version="4.2.0" xmlns="http://apache.org/cordova/ns/plugins/1.0"
+<plugin id="pspdfkit-cordova-android" version="4.2.1" xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
     <name>PSPDFKit-Android</name>
     <description>Integration of the PSPDFKit for Android library.</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
     <info><![CDATA[
 You're almost set up for using PSPDFKit-Android for Apache Cordova! Two more steps:
 
-  1) Place your PSPDFKit library aar file into the `platforms/android/libs/` directory of your project.
+  1) Place your PSPDFKit library aar file into the `platforms/android/app/libs/` directory of your project.
   2) Add your PSPDFKit license key to the <meta-data name="pspdfkit_license_key"> tag of your AndroidManifest.xml.
 ]]></info>
 
@@ -50,7 +50,7 @@ You're almost set up for using PSPDFKit-Android for Apache Cordova! Two more ste
             </feature>
         </config-file>
 
-        <config-file parent="/*/application" target="AndroidManifest.xml" after="activity">
+        <config-file parent="/*/application" target="app/src/main/AndroidManifest.xml" after="activity">
             <activity android:name="com.pspdfkit.ui.PdfActivity"
                       android:theme="@style/PSPDFKit.Theme"
                       android:windowSoftInputMode="adjustNothing"/>


### PR DESCRIPTION
## Resolves #25 

This PR 

* Bumps the minimum required `cordova-android` plugin version to 7.0.0. It further migrates plugin files to the new app structure of Cordova 7.
* Bumps the PSPDFKit/Cordova-Android plugin version to 4.2.1. This plugin is now fully tested with PSPDFKit 4.2.1 for Android.