### PR TITLE
Update plugin for PSPDFKit 4.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ You can use the `options` parameter to configure PSPDFKit. Here is a list of val
 ```javascript
 var options {
 	backgroundColor: '#EFEFEF', // hex-color of the page background
-	disableOutline: true, // hide the outline menu (default: false)
-	disableShare: true, // hide share button (default: false)
-	disablePrinting: true, // hide option to print (default: false)
-	disableBookmarkList: true, // hide bookmark list (default: false)
 	disableAnnotationList: true, // hide annotation list (default: false)
-	disableDocumentEditor: true, // hide document editor (default: false)
+	disableAnnotationNoteHinting: true, // hide small notes next to annotations that have a text set (default: false)
 	disableBookmarkEditing: true, // hide bookmark editing (default: false)
+	disableBookmarkList: true, // hide bookmark list (default: false)
+	disableCopyPaste: true, // disable annotation copy/paste (default: false)
+	disableDocumentEditor: true, // hide document editor (default: false)
+	disableOutline: true, // hide the outline menu (default: false)
+	disablePrinting: true, // hide option to print (default: false)
+	disableShare: true, // hide share button (default: false)
+	disableUndoRedo: true, // disable undo/redo system (default: false)      
 	hidePageLabels: true, // hide page labels (if available in PDF) in page overlay and thumbnail grid (default: false)  
 	hidePageNumberOverlay: false, // hide the overlay showing the current page (default: false)
 	thumbnailBarMode: PSPDFKit.ThumbnailBarMode.THUMBNAIL_BAR_MODE_DEFAULT, // show static thumbnail bar. Also valid: THUMBNAIL_BAR_MODE_DEFAULT, THUMBNAIL_BAR_MODE_SCROLLABLE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-android",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "Integration of the PSPDFKit for Android library.",
   "cordova": {
     "id": "pspdfkit-cordova-android",
@@ -21,7 +21,7 @@
   ],
   "engines": {
       "cordovaDependencies": {
-        "4.2.1": { "cordova-android": ">=7.0.0" }
+        "4.3.0": { "cordova-android": ">=7.0.0" }
       }
   },
   "author": "PSPDFKit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -11,7 +11,7 @@
   ~   UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
   ~   This notice may not be removed from this file.
 -->
-<plugin id="pspdfkit-cordova-android" version="4.2.1" xmlns="http://apache.org/cordova/ns/plugins/1.0"
+<plugin id="pspdfkit-cordova-android" version="4.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
     <name>PSPDFKit-Android</name>
     <description>Integration of the PSPDFKit for Android library.</description>

--- a/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
+++ b/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
@@ -113,24 +113,33 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
             final Object value = options.get(option);
 
             try {
-                if ("backgroundColor".equals(option)) {
+                if ("autosaveEnabled".equals(option)) {
+                    builder.autosaveEnabled((Boolean) value);
+                } else if ("backgroundColor".equals(option)) {
                     builder.backgroundColor(Color.parseColor((String) value));
+                } else if ("disableAnnotationList".equals(option) && ((Boolean) value)) {
+                    builder.disableAnnotationList();
+                } else if ("disableAnnotationNoteHinting".equals(option)) {
+                    builder.setAnnotationNoteHintingEnabled(!(Boolean) value);
+                } else if ("disableBookmarkEditing".equals(option) && ((Boolean) value)) {
+                    builder.disableBookmarkEditing();
+                } else if ("disableBookmarkList".equals(option) && ((Boolean) value)) {
+                    builder.disableBookmarkList();
+                } else if("disableCopyPaste".equals(option)) {
+                    if((Boolean) value) builder.disableCopyPaste();
+                    else builder.enableCopyPaste();
+                } else if ("disableDocumentEditor".equals(option) && ((Boolean) value)) {
+                    builder.disableDocumentEditor();
                 } else if ("disableOutline".equals(option) && ((Boolean) value)) {
                     builder.disableOutline();
+                } else if ("disablePrinting".equals(option) && ((Boolean) value)) {
+                    builder.disablePrinting();
                 } else if ("disableSearch".equals(option) && ((Boolean) value)) {
                     builder.disableSearch();
                 } else if ("disableShare".equals(option) && ((Boolean) value)) {
                     builder.disableShare();
-                } else if ("disablePrinting".equals(option) && ((Boolean) value)) {
-                    builder.disablePrinting();
-                } else if ("disableBookmarkList".equals(option) && ((Boolean) value)) {
-                    builder.disableBookmarkList();
-                } else if ("disableAnnotationList".equals(option) && ((Boolean) value)) {
-                    builder.disableAnnotationList();
-                } else if ("disableDocumentEditor".equals(option) && ((Boolean) value)) {
-                    builder.disableDocumentEditor();
-                } else if ("disableBookmarkEditing".equals(option) && ((Boolean) value)) {
-                    builder.disableBookmarkEditing();
+                } else if ("disableUndoRedo".equals(option)) {
+                    builder.undoEnabled(!(Boolean) value);
                 } else if ("hidePageLabels".equals(option) && ((Boolean) value)) {
                     builder.hidePageLabels();
                 } else if ("hidePageNumberOverlay".equals(option) && ((Boolean) value)) {
@@ -168,8 +177,6 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
                     if ("SEARCH_INLINE".equals(searchType)) builder.setSearchType(PdfActivityConfiguration.SEARCH_INLINE);
                     else if ("SEARCH_MODULAR".equals(searchType)) builder.setSearchType(PdfActivityConfiguration.SEARCH_MODULAR);
                     else throw new IllegalArgumentException(String.format("Invalid search type: %s", value));
-                } else if ("autosaveEnabled".equals(option)) {
-                    builder.autosaveEnabled(options.getBoolean("autosaveEnabled"));
                 } else if ("annotationEditing".equals(option)) {
                     final JSONObject annotationEditing = options.getJSONObject("annotationEditing");
                     final Iterator<String> annotationOptionIterator = annotationEditing.keys();

--- a/src/android/pspdfkit.gradle
+++ b/src/android/pspdfkit.gradle
@@ -35,5 +35,7 @@ dependencies {
     compile 'io.reactivex.rxjava2:rxjava:2.1.3'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     compile 'com.getkeepsafe.relinker:relinker:1.2.2'
+    compile 'com.facebook.device.yearclass:yearclass:2.0.0'
+    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.2.20'
     compile 'com.pspdfkit:pspdfkit:+@aar'
 }


### PR DESCRIPTION
This PR updates the cordova plugin for use with PSPDFKit 4.3.0 for Android.

* Bumps various plugin versions to 4.3.0
* Adds missing dependencies that were introduced with PSPDFKit 4.3.0
* Adds new configuration options `disableUndoRedo`, `disableCopyPaste`, and `disableAnnotationNoteHinting`