### PR TITLE
Update to PSPDFKit 5.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ var options {
     disableDocumentEditor: true, // hide document editor (default: false)
     disableOutline: true, // hide the outline menu (default: false)
     disablePrinting: true, // hide option to print (default: false)
-    disableShare: true, // hide share button (default: false)
     disableUndoRedo: true, // disable undo/redo system (default: false)
     hidePageLabels: true, // hide page labels (if available in PDF) in page overlay and thumbnail grid (default: false)
     hidePageNumberOverlay: false, // hide the overlay showing the current page (default: false)
@@ -81,6 +80,23 @@ var options {
     pageFitMode: PSPDFKit.PageFitMode.FIT_TO_WIDTH, // also valid: PSPDFKit.PageFitMode.FIT_TO_SCREEN
     scrollDirection: PSPDFKit.PageScrollDirection.VERTICAL, // also valid: PSPDFKit.PageScrollDirection.HORIZONTAL
     scrollMode: PSPDFKit.ScrollMode.CONTINUOUS, // also valid: PSPDFKit.ScrollMode.PER_PAGE
+    // Configures which share actions should be visible in the user interface. (default: all enabled)
+    shareFeatures: [
+        /** Document sharing inside the activity. */
+        PSPDFKit.ShareFeatures.DOCUMENT_SHARING,
+        /** Sharing of embedded files (on file annotations). */
+        PSPDFKit.ShareFeatures.EMBEDDED_FILE_SHARING,
+        /** Sharing of text from selected free text annotations. */
+        PSPDFKit.ShareFeatures.FREE_TEXT_ANNOTATION_SHARING,
+        /** Sharing of selected image annotations. */
+        PSPDFKit.ShareFeatures.IMAGE_SHARING,
+        /** Sharing of text from selected note annotations. */
+        PSPDFKit.ShareFeatures.NOTE_ANNOTATION_SHARING,
+        /** Sharing of text from annotation contents or comments. */
+        PSPDFKit.ShareFeatures.NOTE_EDITOR_CONTENT_SHARING,
+        /** Sharing of selected text. */
+        PSPDFKit.ShareFeatures.TEXT_SELECTION_SHARING
+    ],
     invertColors: false, // invert rendered colors (default: false)
     toGrayscale: true, // render document in grayscale only (default: false)
     title: "My PSPDFKit app", // title displayed in the viewer action bar
@@ -111,7 +127,7 @@ Create a new Apache Cordova project from your command line using the [Apache Cor
 
 > Important: Your app's package name (in the above example `com.example.pdfapp`) has to match your PSPDFKit license name or PSPDFKit will throw an exception. If you don't have a license yet, you can request an evaluation license of PSPDFKit at https://pspdfkit.com/try.
 
-Add Android platform support to your project. Right now, PSPDFKit 5.0.1 for Cordova is only compatible with the nightly build of `cordova-android` (until https://github.com/apache/cordova-android/pull/507 is available on the stable npm channel):
+Add Android platform support to your project. Right now, PSPDFKit 5.1.1 for Cordova is only compatible with the nightly build of `cordova-android` (until https://github.com/apache/cordova-android/pull/507 is available on the stable npm channel):
 
     cordova platform add android@8.0.0-nightly.2018.11.23.ef243418
 
@@ -171,7 +187,7 @@ It will then ask you if you want to integrate your new app with Cordova, answer 
 cd todo
 ```
 
-Add Android platform support. Right now, PSPDFKit 5.0.1 for Cordova is only compatible with the nightly build of `cordova-android` (until https://github.com/apache/cordova-android/pull/507 is available on the stable npm channel):
+Add Android platform support. Right now, PSPDFKit 5.1.1 for Cordova is only compatible with the nightly build of `cordova-android` (until https://github.com/apache/cordova-android/pull/507 is available on the stable npm channel):
 
 ```shell
 ionic cordova platform add android@8.0.0-nightly.2018.11.23.ef243418

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-android",
-  "version": "5.0.1",
+  "version": "5.1.1",
   "description": "Integration of the PSPDFKit for Android library.",
   "cordova": {
     "id": "pspdfkit-cordova-android",
@@ -21,7 +21,7 @@
   ],
   "engines": {
       "cordovaDependencies": {
-        "5.0.1": { "cordova-android": "8.0.0-nightly.2018.11.23.ef243418" }
+        "5.1.1": { "cordova-android": "8.0.0-nightly.2018.11.23.ef243418" }
       }
   },
   "author": "PSPDFKit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
   ~   UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
   ~   This notice may not be removed from this file.
 -->
-<plugin id="pspdfkit-cordova-android" version="5.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0"
+<plugin id="pspdfkit-cordova-android" version="5.1.1" xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
     <name>PSPDFKit-Android</name>
     <description>Integration of the PSPDFKit for Android library.</description>
@@ -68,4 +68,6 @@ In case there are issues, feel free to reach out to our support team at https://
                       android:windowSoftInputMode="adjustNothing"/>
         </config-file>
     </platform>
+
+    <dependency id="cordova-plugin-enable-multidex"/>
 </plugin>

--- a/src/android/config.gradle
+++ b/src/android/config.gradle
@@ -51,5 +51,5 @@ if (pspdfkitIsDemo == null) {
 ext.pspdfkitMavenModuleName = pspdfkitIsDemo ? 'pspdfkit-demo' : 'pspdfkit'
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {
-    ext.pspdfkitVersion = '5.0.1'
+    ext.pspdfkitVersion = '5.1.1'
 }

--- a/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
+++ b/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
@@ -208,8 +208,8 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
     /** Converts the given string array to an {@link EnumSet} of {@link ShareFeatures}. */
     private EnumSet<ShareFeatures> parseShareFeatures(@Nullable JSONArray shareFeatures) throws JSONException {
         EnumSet<ShareFeatures> features = ShareFeatures.none();
-        if(shareFeatures != null) {
-            for(int i = 0; i < shareFeatures.length(); i++) {
+        if (shareFeatures != null) {
+            for (int i = 0; i < shareFeatures.length(); i++) {
                 final ShareFeatures feature = ShareFeatures.valueOf(shareFeatures.getString(i));
                 features.add(feature);
             }

--- a/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
+++ b/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
@@ -15,8 +15,6 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.ContextThemeWrapper;
 
@@ -27,6 +25,7 @@ import com.pspdfkit.configuration.activity.ThumbnailBarMode;
 import com.pspdfkit.configuration.page.PageFitMode;
 import com.pspdfkit.configuration.page.PageScrollDirection;
 import com.pspdfkit.configuration.page.PageScrollMode;
+import com.pspdfkit.configuration.sharing.ShareFeatures;
 import com.pspdfkit.preferences.PSPDFKitPreferences;
 import com.pspdfkit.ui.PdfActivity;
 
@@ -38,8 +37,11 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.File;
+import java.util.EnumSet;
 import java.util.Iterator;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class PSPDFKitCordovaPlugin extends CordovaPlugin {
 
@@ -132,8 +134,8 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
                     builder.disablePrinting();
                 } else if ("disableSearch".equals(option) && ((Boolean) value)) {
                     builder.disableSearch();
-                } else if ("disableShare".equals(option) && ((Boolean) value)) {
-                    builder.disableShare();
+                } else if ("shareFeatures".equals(option)) {
+                    builder.setEnabledShareFeatures(parseShareFeatures((JSONArray) value));
                 } else if ("disableUndoRedo".equals(option)) {
                     builder.undoEnabled(!(Boolean) value);
                 } else if ("hidePageLabels".equals(option) && ((Boolean) value)) {
@@ -203,6 +205,18 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
         return builder.build();
     }
 
+    /** Converts the given string array to an {@link EnumSet} of {@link ShareFeatures}. */
+    private EnumSet<ShareFeatures> parseShareFeatures(@Nullable JSONArray shareFeatures) throws JSONException {
+        EnumSet<ShareFeatures> features = ShareFeatures.none();
+        if(shareFeatures != null) {
+            for(int i = 0; i < shareFeatures.length(); i++) {
+                final ShareFeatures feature = ShareFeatures.valueOf(shareFeatures.getString(i));
+                features.add(feature);
+            }
+        }
+        return features;
+    }
+
     /**
      * Ensures that Javascript "null" strings are correctly converted to javas <code>null</code>.
      */
@@ -232,15 +246,12 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
      * @param callbackContext Cordova callback.
      */
     private void showDocumentFromAssets(@NonNull final String assetPath, @Nullable final String password, @NonNull final PdfActivityConfiguration configuration, @NonNull final CallbackContext callbackContext) {
-        ExtractAssetTask.extract(assetPath, cordova.getActivity(), new ExtractAssetTask.OnDocumentExtractedCallback() {
-            @Override
-            public void onDocumentExtracted(File documentFile) {
-                if (documentFile != null) {
-                    showDocumentForUri(Uri.fromFile(documentFile), password, configuration);
-                    callbackContext.success();
-                } else {
-                    callbackContext.error("Could not load '" + assetPath + "' from the assets.");
-                }
+        ExtractAssetTask.extract(assetPath, cordova.getActivity(), documentFile -> {
+            if (documentFile != null) {
+                showDocumentForUri(Uri.fromFile(documentFile), password, configuration);
+                callbackContext.success();
+            } else {
+                callbackContext.error("Could not load '" + assetPath + "' from the assets.");
             }
         });
     }

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-android-tests",
-  "version": "5.0.1",
+  "version": "5.1.1",
   "description": "Test suite of the PSPDFKit for Android library Cordova plugin.",
   "cordova": {
     "id": "pspdfkit-cordova-android-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -9,7 +9,7 @@
 -->
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="pspdfkit-cordova-android-tests"
-        version="5.0.1">
+        version="5.1.1">
     <name>PSPDFKit-Android Tests</name>
     <license>MIT</license>
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -6,102 +6,128 @@
  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
  This notice may not be removed from this file.
  */
-exports.defineAutoTests = function () {
-    describe('PSPSDFKit (window.PSPDFKit)', function () {
-        it("should exist", function () {
-            expect(window.PSPDFKit).toBeDefined();
-        });
-
-        describe('showDocument', function() {
-            it('should exist', function () {
-                expect(window.PSPDFKit.showDocument).toBeDefined();
-            });
-        });
-
-        describe('showDocumentFromAssets', function() {
-            it('should exist', function () {
-                expect(window.PSPDFKit.showDocumentFromAssets).toBeDefined();
-            });
-        });
-
-        describe('ScrollMode', function() {
-          it('should exist', function () {
-              expect(window.PSPDFKit.ScrollMode).toBeDefined();
-          });
-        });
-
-        describe('PageFitMode', function() {
-          it('should exist', function () {
-              expect(window.PSPDFKit.PageFitMode).toBeDefined();
-          });
-        });
-
-        describe('PageScrollDirection', function() {
-          it('should exist', function () {
-              expect(window.PSPDFKit.PageScrollDirection).toBeDefined();
-          });
-        });
-
-        describe('SearchType', function() {
-          it('should exist', function () {
-              expect(window.PSPDFKit.SearchType).toBeDefined();
-          });
-        });
-
-        describe('ThumbnailBarMode', function() {
-          it('should exist', function () {
-              expect(window.PSPDFKit.ThumbnailBarMode).toBeDefined();
-          });
-        })
+exports.defineAutoTests = function() {
+  describe("PSPSDFKit (window.PSPDFKit)", function() {
+    it("should exist", function() {
+      expect(window.PSPDFKit).toBeDefined();
     });
+
+    describe("showDocument", function() {
+      it("should exist", function() {
+        expect(window.PSPDFKit.showDocument).toBeDefined();
+      });
+    });
+
+    describe("showDocumentFromAssets", function() {
+      it("should exist", function() {
+        expect(window.PSPDFKit.showDocumentFromAssets).toBeDefined();
+      });
+    });
+
+    describe("ScrollMode", function() {
+      it("should exist", function() {
+        expect(window.PSPDFKit.ScrollMode).toBeDefined();
+      });
+    });
+
+    describe("PageFitMode", function() {
+      it("should exist", function() {
+        expect(window.PSPDFKit.PageFitMode).toBeDefined();
+      });
+    });
+
+    describe("PageScrollDirection", function() {
+      it("should exist", function() {
+        expect(window.PSPDFKit.PageScrollDirection).toBeDefined();
+      });
+    });
+
+    describe("SearchType", function() {
+      it("should exist", function() {
+        expect(window.PSPDFKit.SearchType).toBeDefined();
+      });
+    });
+
+    describe("ThumbnailBarMode", function() {
+      it("should exist", function() {
+        expect(window.PSPDFKit.ThumbnailBarMode).toBeDefined();
+      });
+    });
+
+    describe("ShareFeatures", function() {
+      it("should exist", function() {
+        expect(window.PSPDFKit.ShareFeatures).toBeDefined();
+      });
+    });
+  });
 };
 
 exports.defineManualTests = function(contentEl, createActionButton) {
+  createActionButton("Open Document", function() {
+    var asset = "www/Guide.pdf";
+    var options = {};
+    console.log("Opening document " + asset);
+    window.PSPDFKit.showDocumentFromAssets(
+      asset,
+      options,
+      function() {
+        console.log("Document was successfully loaded.");
+      },
+      function(error) {
+        console.log("Error while loading the document:" + error);
+      }
+    );
+  });
 
-    createActionButton('Open Document', function() {
-        var asset = 'www/Guide.pdf';
+  createActionButton("Vertical continuous scrolling", function() {
+    var asset = "www/Guide.pdf";
+    var options = {
+      scrollDirection: PSPDFKit.PageScrollDirection.VERTICAL,
+      scrollMode: PSPDFKit.ScrollMode.CONTINUOUS,
+      title: "Custom Title",
+      page: 2,
+      useImmersiveMode: true,
+      thumbnailBarMode: PSPDFKit.ThumbnailBarMode.THUMBNAIL_BAR_MODE_SCROLLABLE,
+      shareFeatures: [],
+      disablePrinting: true
+    };
 
-        console.log('Opening document ' + asset);
-        window.PSPDFKit.showDocumentFromAssets(asset, {}, function() {
-            console.log("Document was successfully loaded.");
-        }, function(error) {
-            console.log('Error while loading the document:' + error)
-        });
-    });
+    console.log("Opening document " + asset);
 
-    createActionButton('Vertical continuous scrolling', function() {
-        var asset = 'www/Guide.pdf';
-        var options = {
-          scrollDirection: PSPDFKit.PageScrollDirection.VERTICAL,
-          scrollMode: PSPDFKit.ScrollMode.CONTINUOUS,
-          title: "Custom Title",
-          page: 2,
-          useImmersiveMode: true,
-          thumbnailBarMode: PSPDFKit.ThumbnailBarMode.THUMBNAIL_BAR_MODE_SCROLLABLE
-        };
+    window.PSPDFKit.showDocumentFromAssets(
+      asset,
+      options,
+      function() {
+        console.log("Document was successfully loaded.");
+      },
+      function(error) {
+        console.log("Error while loading the document:" + error);
+      }
+    );
+  });
 
-        console.log('Opening document ' + asset);
+  createActionButton("Password protected document", function() {
+    var asset = "www/password.pdf";
+    var options = {
+      title: "Password protected document",
+      password: "test123",
+      shareFeatures: [
+        PSPDFKit.ShareFeatures.TEXT_SELECTION_SHARING,
+        PSPDFKit.ShareFeatures.NOTE_ANNOTATION_SHARING
+      ]
+    };
 
-        window.PSPDFKit.showDocumentFromAssets(asset, options, function() {
-            console.log("Document was successfully loaded.");
-        }, function(error) {
-            console.log('Error while loading the document:' + error)
-        });
-    });
+    console.log("Opening encrypted document " + asset);
 
-    createActionButton('Password protected document', function() {
-        var asset = 'www/password.pdf';
-        var options = {
-          title: "Password protected document",
-          password: "test123"
-        };
-
-        console.log('Opening encrypted document ' + asset);
-
-        window.PSPDFKit.showDocumentFromAssets(asset, options, function() {
-            console.log("Document was successfully loaded.");
-        }, function(error) {
-            console.log('Error while loading the document:' + error)
-        });
-    });
+    window.PSPDFKit.showDocumentFromAssets(
+      asset,
+      options,
+      function() {
+        console.log("Document was successfully loaded.");
+      },
+      function(error) {
+        console.log("Error while loading the document:" + error);
+      }
+    );
+  });
 };

--- a/www/PSPDFKit.js
+++ b/www/PSPDFKit.js
@@ -125,3 +125,25 @@ exports.ThumbnailBarMode = {
    */
   THUMBNAIL_BAR_MODE_NONE: "THUMBNAIL_BAR_MODE_NONE"
 };
+
+/**
+ * Constant values used for setting the 'shareFeatures' option. These 
+ * settings control the visibility of share actions inside the user
+ * interface.
+ */
+exports.ShareFeatures = {
+  /** Document sharing inside the activity. */
+  DOCUMENT_SHARING: "DOCUMENT_SHARING",
+  /** Sharing of embedded files (on file annotations). */
+  EMBEDDED_FILE_SHARING: "EMBEDDED_FILE_SHARING",
+  /** Sharing of text from selected free text annotations. */
+  FREE_TEXT_ANNOTATION_SHARING: "FREE_TEXT_ANNOTATION_SHARING",
+  /** Sharing of selected image annotations. */
+  IMAGE_SHARING: "IMAGE_SHARING",
+  /** Sharing of text from selected note annotations. */
+  NOTE_ANNOTATION_SHARING: "NOTE_ANNOTATION_SHARING",
+  /** Sharing of text from annotation contents or comments. */
+  NOTE_EDITOR_CONTENT_SHARING: "NOTE_EDITOR_CONTENT_SHARING",
+  /** Sharing of selected text. */
+  TEXT_SELECTION_SHARING: "TEXT_SELECTION_SHARING"
+};


### PR DESCRIPTION
This PR updates the wrapper to PSPDFKit 5.1.1 for Android. Furthermore, it migrates to the newer `shareOptions` configuration option, which replaces the outdated `disableShare` option.