### PR TITLE
Update to PSPDFKit 5.3 for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ PSPDFKit.showDocumentFromAssets(assetPath, options, success, fail);
 ## Supported Platforms
 
 - Android SDK API level 19+ / Android 4.4+ (KitKat)
-- Cordova Android 7+.
+- Cordova Android 8+.
 
 ## Options
 
@@ -127,21 +127,13 @@ Create a new Apache Cordova project from your command line using the [Apache Cor
 
 > Important: Your app's package name (in the above example `com.example.pdfapp`) has to match your PSPDFKit license name or PSPDFKit will throw an exception. If you don't have a license yet, you can request an evaluation license of PSPDFKit at https://pspdfkit.com/try.
 
-Add Android platform support to your project. Right now, PSPDFKit 5.3.0 for Cordova is only compatible with the nightly build of `cordova-android` (until https://github.com/apache/cordova-android/pull/507 is available on the stable npm channel):
+Add Android platform support to your project. This plugin requires the latest `cordova-android` plugin 8+.
 
-    cordova platform add android@8.0.0-nightly.2018.11.23.ef243418
+    cordova platform add android@8.0.0
 
 Install the PSPDFKit plugin:
 
     cordova plugin add https://github.com/PSPDFKit/Cordova-Android.git
-
-Setup the minimum and target SDK versions of the Android SDK inside your Android app's `platforms/android/gradle.properties` file. Also, since PSPDFKit 5 for Android uses Java 8, you need to enable D8 for your builds:
-
-```properties
-cdvCompileSdkVersion=android-28
-cdvBuildToolsVersion=28.0.3
-android.enableD8=true
-```
 
 Next you need to setup your PSPDFKit license key and Maven password. If you don't have a license key or Maven password yet, you can get them by requesting an evaluation version of PSPDFKit at https://pspdfkit.com/try. Inside your Android app's `platforms/android/local.properties` file, specify the `pspdfkit.password` and `pspdfkit.license` properties:
 
@@ -187,24 +179,16 @@ It will then ask you if you want to integrate your new app with Cordova, answer 
 cd todo
 ```
 
-Add Android platform support. Right now, PSPDFKit 5.3.0 for Cordova is only compatible with the nightly build of `cordova-android` (until https://github.com/apache/cordova-android/pull/507 is available on the stable npm channel):
+Add Android platform support to your project. This plugin requires the latest `cordova-android` plugin 8+.
 
 ```shell
-ionic cordova platform add android@8.0.0-nightly.2018.11.23.ef243418
+ionic cordova platform add android@8.0.0
 ```
 
 Install the PSPDFKit plugin:
 
 ```shell
 ionic cordova plugin add https://github.com/PSPDFKit/Cordova-Android.git
-```
-
-Setup the minimum and target SDK versions of the Android SDK inside your Android app's `platforms/android/gradle.properties` file. Also, since PSPDFKit 5 for Android uses Java 8, you need to enable D8 for your builds:
-
-```properties
-cdvCompileSdkVersion=android-28
-cdvBuildToolsVersion=28.0.3
-android.enableD8=true
 ```
 
 Next you need to setup your PSPDFKit license key and Maven password. If you don't have a license key or Maven password yet, you can get them by requesting an evaluation version of PSPDFKit at https://pspdfkit.com/try. Specify the `pspdfkit.password` and `pspdfkit.license` properties inside your Android app's `platforms/android/local.properties` file, create the file if it does not exist:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Create a new Apache Cordova project from your command line using the [Apache Cor
 
 > Important: Your app's package name (in the above example `com.example.pdfapp`) has to match your PSPDFKit license name or PSPDFKit will throw an exception. If you don't have a license yet, you can request an evaluation license of PSPDFKit at https://pspdfkit.com/try.
 
-Add Android platform support to your project. Right now, PSPDFKit 5.1.1 for Cordova is only compatible with the nightly build of `cordova-android` (until https://github.com/apache/cordova-android/pull/507 is available on the stable npm channel):
+Add Android platform support to your project. Right now, PSPDFKit 5.3.0 for Cordova is only compatible with the nightly build of `cordova-android` (until https://github.com/apache/cordova-android/pull/507 is available on the stable npm channel):
 
     cordova platform add android@8.0.0-nightly.2018.11.23.ef243418
 
@@ -187,7 +187,7 @@ It will then ask you if you want to integrate your new app with Cordova, answer 
 cd todo
 ```
 
-Add Android platform support. Right now, PSPDFKit 5.1.1 for Cordova is only compatible with the nightly build of `cordova-android` (until https://github.com/apache/cordova-android/pull/507 is available on the stable npm channel):
+Add Android platform support. Right now, PSPDFKit 5.3.0 for Cordova is only compatible with the nightly build of `cordova-android` (until https://github.com/apache/cordova-android/pull/507 is available on the stable npm channel):
 
 ```shell
 ionic cordova platform add android@8.0.0-nightly.2018.11.23.ef243418

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "engines": {
       "cordovaDependencies": {
-        "5.3.0": { "cordova-android": "8.0.0-nightly.2018.11.23.ef243418" }
+        "5.3.0": { "cordova-android": ">=8.0.0" }
       }
   },
   "author": "PSPDFKit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-android",
-  "version": "5.1.1",
+  "version": "5.3.0",
   "description": "Integration of the PSPDFKit for Android library.",
   "cordova": {
     "id": "pspdfkit-cordova-android",
@@ -21,7 +21,7 @@
   ],
   "engines": {
       "cordovaDependencies": {
-        "5.1.1": { "cordova-android": "8.0.0-nightly.2018.11.23.ef243418" }
+        "5.3.0": { "cordova-android": "8.0.0-nightly.2018.11.23.ef243418" }
       }
   },
   "author": "PSPDFKit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
   ~   UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
   ~   This notice may not be removed from this file.
 -->
-<plugin id="pspdfkit-cordova-android" version="5.1.1" xmlns="http://apache.org/cordova/ns/plugins/1.0"
+<plugin id="pspdfkit-cordova-android" version="5.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
     <name>PSPDFKit-Android</name>
     <description>Integration of the PSPDFKit for Android library.</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -69,5 +69,5 @@ In case there are issues, feel free to reach out to our support team at https://
         </config-file>
     </platform>
 
-    <dependency id="cordova-plugin-enable-multidex"/>
+    <dependency id="cordova-plugin-enable-multidex" url="https://github.com/PSPDFKit-labs/cordova-plugin-enable-multidex.git"/>
 </plugin>

--- a/src/android/config.gradle
+++ b/src/android/config.gradle
@@ -51,5 +51,5 @@ if (pspdfkitIsDemo == null) {
 ext.pspdfkitMavenModuleName = pspdfkitIsDemo ? 'pspdfkit-demo' : 'pspdfkit'
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {
-    ext.pspdfkitVersion = '5.1.1'
+    ext.pspdfkitVersion = '5.3.0'
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova-android-tests",
-  "version": "5.1.1",
+  "version": "5.3.0",
   "description": "Test suite of the PSPDFKit for Android library Cordova plugin.",
   "cordova": {
     "id": "pspdfkit-cordova-android-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -9,7 +9,7 @@
 -->
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="pspdfkit-cordova-android-tests"
-        version="5.1.1">
+        version="5.3.0">
     <name>PSPDFKit-Android Tests</name>
     <license>MIT</license>
 


### PR DESCRIPTION
This PR updates the plugin to PSPDFKit 5.3 for Android. It also upgrades the plugin to the latest stable version 8.0 of `cordova-android` which should make integration a bit simpler (due to not requiring users to bump various properties).

Due to a breaking change in the way Cordova now imports libraries, I had to fork the previously used multidex library, and applied the necessary migration steps. I also took the opportunity to upgrade the multidex plugin to AndroidX: https://github.com/PSPDFKit-labs/cordova-plugin-enable-multidex/commit/b161e9473ba58b663ac5888acb3de1983c77ce40