### PR TITLE
Instant JSON API: Remove annotation

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,7 @@ In case there are issues, feel free to reach out to our support team at https://
         <source-file src="src/android/java/com/pspdfkit/cordova/action/annotation/ApplyInstantJsonAction.java" target-dir="src/com/pspdfkit/cordova/action/annotation"/>
         <source-file src="src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java" target-dir="src/com/pspdfkit/cordova/action/annotation"/>
         <source-file src="src/android/java/com/pspdfkit/cordova/action/annotation/GetAllUnsavedAnnotationsAction.java" target-dir="src/com/pspdfkit/cordova/action/annotation"/>
+        <source-file src="src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java" target-dir="src/com/pspdfkit/cordova/action/annotation"/>
         <source-file src="src/android/java/com/pspdfkit/cordova/action/document/SaveDocumentAction.java" target-dir="src/com/pspdfkit/cordova/action/document"/>
         <source-file src="src/android/java/com/pspdfkit/cordova/action/document/ShowDocumentAction.java" target-dir="src/com/pspdfkit/cordova/action/document"/>
         <source-file src="src/android/java/com/pspdfkit/cordova/action/document/ShowDocumentFromAssetsAction.java" target-dir="src/com/pspdfkit/cordova/action/document"/>

--- a/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
+++ b/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
@@ -20,6 +20,7 @@ import com.pspdfkit.cordova.action.annotation.AddAnnotationAction;
 import com.pspdfkit.cordova.action.annotation.ApplyInstantJsonAction;
 import com.pspdfkit.cordova.action.annotation.GetAllUnsavedAnnotationsAction;
 import com.pspdfkit.cordova.action.annotation.GetAnnotationsAction;
+import com.pspdfkit.cordova.action.annotation.RemoveAnnotationAction;
 import com.pspdfkit.cordova.action.document.SaveDocumentAction;
 import com.pspdfkit.cordova.action.document.ShowDocumentFromAssetsAction;
 import com.pspdfkit.cordova.action.document.ShowDocumentAction;
@@ -69,6 +70,7 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
             new DismissAction("dismiss", this),
             new SaveDocumentAction("saveDocument", this),
             new AddAnnotationAction("addAnnotation", this),
+            new RemoveAnnotationAction("removeAnnotation", this),
             new ApplyInstantJsonAction("applyInstantJson", this),
             new GetAnnotationsAction("getAnnotations", this),
             new GetAllUnsavedAnnotationsAction("getAllUnsavedAnnotations", this));

--- a/src/android/java/com/pspdfkit/cordova/Utilities.java
+++ b/src/android/java/com/pspdfkit/cordova/Utilities.java
@@ -3,6 +3,10 @@ package com.pspdfkit.cordova;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.pspdfkit.annotations.AnnotationType;
+
+import java.util.EnumSet;
+
 /**
  * Contains commonly used utility/helper methods.
  */
@@ -39,5 +43,51 @@ public final class Utilities {
   public static String convertJsonNullToJavaNull(@Nullable String value) {
     if (value == null || value.equals("null")) return null;
     return value;
+  }
+
+  public static EnumSet<AnnotationType> getTypeFromString(@Nullable String type) {
+    if (type == null) {
+      return EnumSet.allOf(AnnotationType.class);
+    }
+    if ("pspdfkit/ink".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.INK);
+    }
+    if ("pspdfkit/link".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.LINK);
+    }
+    if ("pspdfkit/markup/highlight".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.HIGHLIGHT);
+    }
+    if ("pspdfkit/markup/squiggly".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.SQUIGGLY);
+    }
+    if ("pspdfkit/markup/strikeout".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.STRIKEOUT);
+    }
+    if ("pspdfkit/markup/underline".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.UNDERLINE);
+    }
+    if ("pspdfkit/note".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.NOTE);
+    }
+    if ("pspdfkit/shape/ellipse".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.CIRCLE);
+    }
+    if ("pspdfkit/shape/line".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.LINE);
+    }
+    if ("pspdfkit/shape/polygon".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.POLYGON);
+    }
+    if ("pspdfkit/shape/polyline".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.POLYLINE);
+    }
+    if ("pspdfkit/shape/rectangle".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.SQUARE);
+    }
+    if ("pspdfkit/text".equalsIgnoreCase(type)) {
+      return EnumSet.of(AnnotationType.FREETEXT);
+    }
+    return EnumSet.noneOf(AnnotationType.class);
   }
 }

--- a/src/android/java/com/pspdfkit/cordova/Utilities.java
+++ b/src/android/java/com/pspdfkit/cordova/Utilities.java
@@ -45,6 +45,11 @@ public final class Utilities {
     return value;
   }
 
+  /**
+   * Converts given string for annotation type into a corresponding {@link EnumSet<AnnotationType>}
+   * @param type string for annotation type to convert
+   * @return corresponding {@link EnumSet<AnnotationType>}
+   */
   public static EnumSet<AnnotationType> getTypeFromString(@Nullable String type) {
     if (type == null) {
       return EnumSet.allOf(AnnotationType.class);

--- a/src/android/java/com/pspdfkit/cordova/Utilities.java
+++ b/src/android/java/com/pspdfkit/cordova/Utilities.java
@@ -50,7 +50,7 @@ public final class Utilities {
    * @param type string for annotation type to convert
    * @return corresponding {@link EnumSet<AnnotationType>}
    */
-  public static EnumSet<AnnotationType> getTypeFromString(@Nullable String type) {
+  public static EnumSet<AnnotationType> getAnnotationTypeFromString(@Nullable String type) {
     if (type == null) {
       return EnumSet.allOf(AnnotationType.class);
     }

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/AddAnnotationAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/AddAnnotationAction.java
@@ -2,11 +2,13 @@ package com.pspdfkit.cordova.action.annotation;
 
 import androidx.annotation.NonNull;
 
+import com.pspdfkit.annotations.Annotation;
 import com.pspdfkit.annotations.AnnotationProvider;
 import com.pspdfkit.cordova.CordovaPdfActivity;
 import com.pspdfkit.cordova.PSPDFKitCordovaPlugin;
 import com.pspdfkit.cordova.action.BasicAction;
 import com.pspdfkit.document.PdfDocument;
+import com.pspdfkit.ui.PdfFragment;
 
 import org.apache.cordova.CallbackContext;
 import org.json.JSONArray;
@@ -27,13 +29,22 @@ public class AddAnnotationAction extends BasicAction {
   @Override
   protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
     String annotationJson = args.getJSONObject(ARG_ANNOTATION_JSON).toString();
-    final PdfDocument document = CordovaPdfActivity.getCurrentActivity().getDocument();
+    CordovaPdfActivity pdfActivity = CordovaPdfActivity.getCurrentActivity();
+
+    final PdfDocument document = pdfActivity.getDocument();
     if (document != null) {
       AnnotationProvider annotationProvider = document.getAnnotationProvider();
-      annotationProvider.addAnnotationToPage(
-          annotationProvider.createAnnotationFromInstantJson(annotationJson)
-      );
+      Annotation annotationFromInstantJson = annotationProvider.createAnnotationFromInstantJson(annotationJson);
+      annotationProvider.addAnnotationToPage(annotationFromInstantJson);
+
+      PdfFragment pdfFragment = pdfActivity.getPdfFragment();
+      if(pdfFragment != null){
+        pdfFragment.notifyAnnotationHasChanged(annotationFromInstantJson);
+      }
+
       callbackContext.success();
+    } else {
+      callbackContext.error("No document is set");
     }
   }
 }

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/AddAnnotationAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/AddAnnotationAction.java
@@ -35,7 +35,6 @@ public class AddAnnotationAction extends BasicAction {
     if (document != null) {
       AnnotationProvider annotationProvider = document.getAnnotationProvider();
       Annotation annotationFromInstantJson = annotationProvider.createAnnotationFromInstantJson(annotationJson);
-      annotationProvider.addAnnotationToPage(annotationFromInstantJson);
 
       PdfFragment pdfFragment = pdfActivity.getPdfFragment();
       if(pdfFragment != null){

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/AddAnnotationAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/AddAnnotationAction.java
@@ -33,8 +33,8 @@ public class AddAnnotationAction extends BasicAction {
 
     final PdfDocument document = pdfActivity.getDocument();
     if (document != null) {
-      AnnotationProvider annotationProvider = document.getAnnotationProvider();
-      Annotation annotationFromInstantJson = annotationProvider.createAnnotationFromInstantJson(annotationJson);
+      Annotation annotationFromInstantJson = document.getAnnotationProvider()
+          .createAnnotationFromInstantJson(annotationJson);
 
       PdfFragment pdfFragment = pdfActivity.getPdfFragment();
       if(pdfFragment != null){

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java
@@ -1,10 +1,8 @@
 package com.pspdfkit.cordova.action.annotation;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.pspdfkit.annotations.Annotation;
-import com.pspdfkit.annotations.AnnotationType;
 import com.pspdfkit.cordova.CordovaPdfActivity;
 import com.pspdfkit.cordova.PSPDFKitCordovaPlugin;
 import com.pspdfkit.cordova.action.BasicAction;
@@ -15,13 +13,11 @@ import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
 
-import java.util.EnumSet;
-
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
 import static com.pspdfkit.cordova.Utilities.convertJsonNullToJavaNull;
-import static com.pspdfkit.cordova.Utilities.getTypeFromString;
+import static com.pspdfkit.cordova.Utilities.getAnnotationTypeFromString;
 
 /**
  * Asynchronously retrieves all annotations of the given type from the given page.
@@ -46,7 +42,7 @@ public class GetAnnotationsAction extends BasicAction {
 
     if (document != null) {
       document.getAnnotationProvider().getAllAnnotationsOfType(
-          getTypeFromString(convertJsonNullToJavaNull(args.getString(ARG_ANNOTATION_TYPE))),
+          getAnnotationTypeFromString(convertJsonNullToJavaNull(args.getString(ARG_ANNOTATION_TYPE))),
           args.getInt(ARG_PAGE_INDEX),
           1)
           .map(Annotation::toInstantJson)

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java
@@ -21,6 +21,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
 import static com.pspdfkit.cordova.Utilities.convertJsonNullToJavaNull;
+import static com.pspdfkit.cordova.Utilities.getTypeFromString;
 
 /**
  * Asynchronously retrieves all annotations of the given type from the given page.
@@ -60,51 +61,5 @@ public class GetAnnotationsAction extends BasicAction {
     } else {
       callbackContext.error("No document is set");
     }
-  }
-
-  private EnumSet<AnnotationType> getTypeFromString(@Nullable String type) {
-    if (type == null) {
-      return EnumSet.allOf(AnnotationType.class);
-    }
-    if ("pspdfkit/ink".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.INK);
-    }
-    if ("pspdfkit/link".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.LINK);
-    }
-    if ("pspdfkit/markup/highlight".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.HIGHLIGHT);
-    }
-    if ("pspdfkit/markup/squiggly".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.SQUIGGLY);
-    }
-    if ("pspdfkit/markup/strikeout".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.STRIKEOUT);
-    }
-    if ("pspdfkit/markup/underline".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.UNDERLINE);
-    }
-    if ("pspdfkit/note".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.NOTE);
-    }
-    if ("pspdfkit/shape/ellipse".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.CIRCLE);
-    }
-    if ("pspdfkit/shape/line".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.LINE);
-    }
-    if ("pspdfkit/shape/polygon".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.POLYGON);
-    }
-    if ("pspdfkit/shape/polyline".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.POLYLINE);
-    }
-    if ("pspdfkit/shape/rectangle".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.SQUARE);
-    }
-    if ("pspdfkit/text".equalsIgnoreCase(type)) {
-      return EnumSet.of(AnnotationType.FREETEXT);
-    }
-    return EnumSet.noneOf(AnnotationType.class);
   }
 }

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
@@ -38,7 +38,7 @@ public class RemoveAnnotationAction extends BasicAction {
     // We can't create an annotation from the Instant JSON since that will attach it to the document,
     // so we manually grab the necessary values.
     int pageIndex = jsonObject.getInt("pageIndex");
-    String name = jsonObject.getString("name");
+    String name = jsonObject.optString("name");
     String type = jsonObject.getString("type");
 
     CordovaPdfActivity pdfActivity = CordovaPdfActivity.getCurrentActivity();
@@ -52,7 +52,7 @@ public class RemoveAnnotationAction extends BasicAction {
     if (document != null) {
       AnnotationProvider annotationProvider = document.getAnnotationProvider();
       annotationProvider.getAllAnnotationsOfType(getAnnotationTypeFromString(type), pageIndex, 1)
-          .filter(annotationToFilter -> name.equals(annotationToFilter.getName()))
+          .filter(annotationToFilter -> !name.isEmpty() && name.equals(annotationToFilter.getName()))
           .subscribeOn(Schedulers.io())
           .observeOn(AndroidSchedulers.mainThread())
           .doOnError(e -> callbackContext.error(e.getMessage()))

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
@@ -18,7 +18,7 @@ import org.json.JSONObject;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
-import static com.pspdfkit.cordova.Utilities.getTypeFromString;
+import static com.pspdfkit.cordova.Utilities.getAnnotationTypeFromString;
 
 /**
  * Removes a given annotation from the current document. The annotation should be in the Instant
@@ -51,7 +51,7 @@ public class RemoveAnnotationAction extends BasicAction {
     final PdfDocument document = pdfActivity.getDocument();
     if (document != null) {
       AnnotationProvider annotationProvider = document.getAnnotationProvider();
-      annotationProvider.getAllAnnotationsOfType(getTypeFromString(type), pageIndex, 1)
+      annotationProvider.getAllAnnotationsOfType(getAnnotationTypeFromString(type), pageIndex, 1)
           .filter(annotationToFilter -> name.equals(annotationToFilter.getName()))
           .subscribeOn(Schedulers.io())
           .observeOn(AndroidSchedulers.mainThread())

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
@@ -15,8 +15,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 
 /**
- * Adds a new annotation to the current document using the Instant JSON Annotation payload:
- * https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
+ * Removes a given annotation from the current document. The annotation should be in the Instant
+ * JSON format: https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
  */
 public class RemoveAnnotationAction extends BasicAction {
 

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
@@ -2,11 +2,13 @@ package com.pspdfkit.cordova.action.annotation;
 
 import androidx.annotation.NonNull;
 
+import com.pspdfkit.annotations.Annotation;
 import com.pspdfkit.annotations.AnnotationProvider;
 import com.pspdfkit.cordova.CordovaPdfActivity;
 import com.pspdfkit.cordova.PSPDFKitCordovaPlugin;
 import com.pspdfkit.cordova.action.BasicAction;
 import com.pspdfkit.document.PdfDocument;
+import com.pspdfkit.ui.PdfFragment;
 
 import org.apache.cordova.CallbackContext;
 import org.json.JSONArray;
@@ -27,13 +29,22 @@ public class RemoveAnnotationAction extends BasicAction {
   @Override
   protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
     String annotationJson = args.getJSONObject(ARG_ANNOTATION_JSON).toString();
-    final PdfDocument document = CordovaPdfActivity.getCurrentActivity().getDocument();
+    CordovaPdfActivity pdfActivity = CordovaPdfActivity.getCurrentActivity();
+
+    final PdfDocument document = pdfActivity.getDocument();
     if (document != null) {
       AnnotationProvider annotationProvider = document.getAnnotationProvider();
-      annotationProvider.addAnnotationToPage(
-          annotationProvider.createAnnotationFromInstantJson(annotationJson)
-      );
+      Annotation annotationFromInstantJson = annotationProvider.createAnnotationFromInstantJson(annotationJson);
+      annotationProvider.removeAnnotationFromPage(annotationFromInstantJson);
+
+      PdfFragment pdfFragment = pdfActivity.getPdfFragment();
+      if(pdfFragment != null){
+        pdfFragment.notifyAnnotationHasChanged(annotationFromInstantJson);
+      }
+
       callbackContext.success();
+    } else {
+      callbackContext.error("No document is set");
     }
   }
 }

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
@@ -1,0 +1,39 @@
+package com.pspdfkit.cordova.action.annotation;
+
+import androidx.annotation.NonNull;
+
+import com.pspdfkit.annotations.AnnotationProvider;
+import com.pspdfkit.cordova.CordovaPdfActivity;
+import com.pspdfkit.cordova.PSPDFKitCordovaPlugin;
+import com.pspdfkit.cordova.action.BasicAction;
+import com.pspdfkit.document.PdfDocument;
+
+import org.apache.cordova.CallbackContext;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+/**
+ * Adds a new annotation to the current document using the Instant JSON Annotation payload:
+ * https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
+ */
+public class RemoveAnnotationAction extends BasicAction {
+
+  private static final int ARG_ANNOTATION_JSON = 0;
+
+  public RemoveAnnotationAction(@NonNull String name, @NonNull PSPDFKitCordovaPlugin plugin) {
+    super(name, plugin);
+  }
+
+  @Override
+  protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
+    String annotationJson = args.getJSONObject(ARG_ANNOTATION_JSON).toString();
+    final PdfDocument document = CordovaPdfActivity.getCurrentActivity().getDocument();
+    if (document != null) {
+      AnnotationProvider annotationProvider = document.getAnnotationProvider();
+      annotationProvider.addAnnotationToPage(
+          annotationProvider.createAnnotationFromInstantJson(annotationJson)
+      );
+      callbackContext.success();
+    }
+  }
+}

--- a/www/PSPDFKit.js
+++ b/www/PSPDFKit.js
@@ -92,6 +92,18 @@ exports.addAnnotation = function(annotation, success, error) {
 };
 
 /**
+ * Removes a given annotation from the current document.  The annotaion is expected to be in Instant
+ * JSON format - https://pspdfkit.com/guides/ios/current/importing-exporting/instant-json/#instant-annotation-json-api
+ *
+ * @param annotation Instant JSON of the annotation to remove.
+ * @param success   Success callback function.
+ * @param error     Error callback function.
+ */
+exports.removeAnnotation = function(annotation, success, error) {
+  exec(success, error, "PSPDFKitCordovaPlugin", "removeAnnotation", [annotation]);
+};
+
+/**
  * Applies the passed in document Instant JSON.
  *
  * @param annotations The document Instant JSON to apply.


### PR DESCRIPTION
Adds following API mappings:
- `removeAnnotation`

Fixes: 
- `addAnnotation` attempting to add annotation twice.