### PR TITLE
New API: XFDF support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -46,6 +46,8 @@ In case there are issues, feel free to reach out to our support team at https://
         <source-file src="src/android/java/com/pspdfkit/cordova/action/document/SaveDocumentAction.java" target-dir="src/com/pspdfkit/cordova/action/document"/>
         <source-file src="src/android/java/com/pspdfkit/cordova/action/document/ShowDocumentAction.java" target-dir="src/com/pspdfkit/cordova/action/document"/>
         <source-file src="src/android/java/com/pspdfkit/cordova/action/document/ShowDocumentFromAssetsAction.java" target-dir="src/com/pspdfkit/cordova/action/document"/>
+        <source-file src="src/android/java/com/pspdfkit/cordova/action/xfdf/ExportXfdfAction.java" target-dir="src/com/pspdfkit/cordova/action/xfdf"/>
+        <source-file src="src/android/java/com/pspdfkit/cordova/action/xfdf/ImportXfdfAction.java" target-dir="src/com/pspdfkit/cordova/action/xfdf"/>
         <source-file src="src/android/java/com/pspdfkit/cordova/action/Action.java" target-dir="src/com/pspdfkit/cordova/action"/>
         <source-file src="src/android/java/com/pspdfkit/cordova/action/ActionManager.java" target-dir="src/com/pspdfkit/cordova/action"/>
         <source-file src="src/android/java/com/pspdfkit/cordova/action/BasicAction.java" target-dir="src/com/pspdfkit/cordova/action"/>

--- a/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
+++ b/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
@@ -1,6 +1,7 @@
 package com.pspdfkit.cordova;
 
 import android.os.Bundle;
+import android.util.Log;
 
 import com.pspdfkit.cordova.event.EventDispatcher;
 import com.pspdfkit.document.PdfDocument;
@@ -16,6 +17,9 @@ import java.io.IOException;
 
 import androidx.annotation.NonNull;
 
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.disposables.Disposable;
+
 import static com.pspdfkit.cordova.Utilities.checkArgumentNotNull;
 
 public class CordovaPdfActivity extends PdfActivity {
@@ -25,6 +29,7 @@ public class CordovaPdfActivity extends PdfActivity {
      * activity.
      */
     private static CordovaPdfActivity currentActivity;
+    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
 
     @NonNull
     private final DocumentListener listener =
@@ -74,10 +79,25 @@ public class CordovaPdfActivity extends PdfActivity {
         currentActivity = null;
     }
 
+    public void addSubscription(Disposable disposable){
+        compositeDisposable.add(disposable);
+    }
+
+    public void disposeSubscriptions(){
+        Log.d("WTF", "subscription is disposed");
+        compositeDisposable.dispose();
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         bindActivity(this);
+    }
+
+    @Override
+    protected void onStop() {
+        disposeSubscriptions();
+        super.onStop();
     }
 
     @Override

--- a/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
+++ b/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
@@ -84,7 +84,6 @@ public class CordovaPdfActivity extends PdfActivity {
     }
 
     public void disposeSubscriptions(){
-        Log.d("WTF", "subscription is disposed");
         compositeDisposable.dispose();
     }
 

--- a/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
+++ b/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
@@ -80,7 +80,7 @@ public class CordovaPdfActivity extends PdfActivity {
 
   /**
    * Adds given {@link Disposable} to disposable collection which will be automatically disposed as
-   * a part of activity lifecycle.
+   * a part of onStop except when it was called as a part of configuration change.
    *
    * @param disposable to add to the disposable collection.
    */
@@ -100,7 +100,9 @@ public class CordovaPdfActivity extends PdfActivity {
 
   @Override
   protected void onStop() {
-    disposeSubscriptions();
+    if(!isChangingConfigurations()){
+      disposeSubscriptions();
+    }
     super.onStop();
   }
 

--- a/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
+++ b/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
@@ -80,7 +80,7 @@ public class CordovaPdfActivity extends PdfActivity {
 
   /**
    * Adds given {@link Disposable} to disposable collection which will be automatically disposed as
-   * a part of onStop except when it was called as a part of configuration change.
+   * a part of onDestroy during activity finishing process.
    *
    * @param disposable to add to the disposable collection.
    */
@@ -99,16 +99,13 @@ public class CordovaPdfActivity extends PdfActivity {
   }
 
   @Override
-  protected void onStop() {
-    if(!isChangingConfigurations()){
-      disposeSubscriptions();
-    }
-    super.onStop();
-  }
-
-  @Override
   protected void onDestroy() {
     releaseActivity();
+
+    if (isFinishing()) {
+      disposeSubscriptions();
+    }
+
     super.onDestroy();
   }
 

--- a/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
+++ b/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
@@ -1,7 +1,8 @@
 package com.pspdfkit.cordova;
 
 import android.os.Bundle;
-import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import com.pspdfkit.cordova.event.EventDispatcher;
 import com.pspdfkit.document.PdfDocument;
@@ -15,8 +16,6 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 
-import androidx.annotation.NonNull;
-
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 
@@ -24,105 +23,113 @@ import static com.pspdfkit.cordova.Utilities.checkArgumentNotNull;
 
 public class CordovaPdfActivity extends PdfActivity {
 
-    /**
-     * For communication with the JavaScript context, we keep a static reference to the current
-     * activity.
-     */
-    private static CordovaPdfActivity currentActivity;
-    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
+  /**
+   * For communication with the JavaScript context, we keep a static reference to the current
+   * activity.
+   */
+  private static CordovaPdfActivity currentActivity;
+  private final CompositeDisposable compositeDisposable = new CompositeDisposable();
 
-    @NonNull
-    private final DocumentListener listener =
-        new SimpleDocumentListener() {
-            @Override
-            public void onDocumentSaved(@NonNull PdfDocument document) {
-                EventDispatcher.getInstance().sendEvent("onDocumentSaved", new JSONObject());
-            }
-
-            @Override
-            public void onDocumentSaveFailed(
-                @NonNull PdfDocument document, @NonNull Throwable exception) {
-                try {
-                    final JSONObject data = new JSONObject();
-                    data.put("message", exception.getMessage());
-                    EventDispatcher.getInstance().sendEvent("onDocumentSaveFailed", data);
-                } catch (JSONException e) {
-                    e.printStackTrace();
-                }
-            }
-        };
-
-    public static CordovaPdfActivity getCurrentActivity() {
-        return currentActivity;
-    }
-
-    private void bindActivity(@NonNull final CordovaPdfActivity activity) {
-        checkArgumentNotNull(activity, "activity");
-        if (currentActivity != null) {
-            throw new IllegalStateException(
-                "EventDispatcher only supports a single CordovaPdfActivity at a time.");
+  @NonNull
+  private final DocumentListener listener =
+      new SimpleDocumentListener() {
+        @Override
+        public void onDocumentSaved(@NonNull PdfDocument document) {
+          EventDispatcher.getInstance().sendEvent("onDocumentSaved", new JSONObject());
         }
-        currentActivity = activity;
-        final PdfFragment pdfFragment = currentActivity.getPdfFragment();
-        if (pdfFragment == null) {
-            throw new IllegalStateException(
-                "EventDispatcher only supports binding to activities that have a fragment instance.");
+
+        @Override
+        public void onDocumentSaveFailed(
+            @NonNull PdfDocument document, @NonNull Throwable exception) {
+          try {
+            final JSONObject data = new JSONObject();
+            data.put("message", exception.getMessage());
+            EventDispatcher.getInstance().sendEvent("onDocumentSaveFailed", data);
+          } catch (JSONException e) {
+            e.printStackTrace();
+          }
         }
-        pdfFragment.addDocumentListener(listener);
-    }
+      };
 
-    private void releaseActivity() {
-        PdfFragment fragment = currentActivity.getPdfFragment();
-        if (fragment != null) {
-            fragment.removeDocumentListener(listener);
-        }
-        currentActivity = null;
-    }
+  public static CordovaPdfActivity getCurrentActivity() {
+    return currentActivity;
+  }
 
-    public void addSubscription(Disposable disposable){
-        compositeDisposable.add(disposable);
+  private void bindActivity(@NonNull final CordovaPdfActivity activity) {
+    checkArgumentNotNull(activity, "activity");
+    if (currentActivity != null) {
+      throw new IllegalStateException(
+          "EventDispatcher only supports a single CordovaPdfActivity at a time.");
     }
+    currentActivity = activity;
+    final PdfFragment pdfFragment = currentActivity.getPdfFragment();
+    if (pdfFragment == null) {
+      throw new IllegalStateException(
+          "EventDispatcher only supports binding to activities that have a fragment instance.");
+    }
+    pdfFragment.addDocumentListener(listener);
+  }
 
-    public void disposeSubscriptions(){
-        compositeDisposable.dispose();
+  private void releaseActivity() {
+    PdfFragment fragment = currentActivity.getPdfFragment();
+    if (fragment != null) {
+      fragment.removeDocumentListener(listener);
     }
+    currentActivity = null;
+  }
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        bindActivity(this);
-    }
+  /**
+   * Adds given {@link Disposable} to disposable collection which will be automatically disposed as
+   * a part of activity lifecycle.
+   *
+   * @param disposable to add to the disposable collection.
+   */
+  public void addSubscription(Disposable disposable) {
+    compositeDisposable.add(disposable);
+  }
 
-    @Override
-    protected void onStop() {
-        disposeSubscriptions();
-        super.onStop();
-    }
+  private void disposeSubscriptions() {
+    compositeDisposable.dispose();
+  }
 
-    @Override
-    protected void onDestroy() {
-        releaseActivity();
-        super.onDestroy();
-    }
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    bindActivity(this);
+  }
 
-    @Override
-    public void finish() {
-        super.finish();
-        // Notify JavaScript listeners that the activity was dismissed.
-        EventDispatcher.getInstance().notifyActivityDismissed();
-    }
+  @Override
+  protected void onStop() {
+    disposeSubscriptions();
+    super.onStop();
+  }
 
-    /** Dismisses this PDF activity. */
-    public void dismiss() {
-        finish();
-    }
+  @Override
+  protected void onDestroy() {
+    releaseActivity();
+    super.onDestroy();
+  }
 
-    public boolean saveDocument() throws IOException {
-        final PdfDocument document = getDocument();
-        if (document != null) {
-            return document.saveIfModified();
-        } else {
-            return false;
-        }
+  @Override
+  public void finish() {
+    super.finish();
+    // Notify JavaScript listeners that the activity was dismissed.
+    EventDispatcher.getInstance().notifyActivityDismissed();
+  }
+
+  /**
+   * Dismisses this PDF activity.
+   */
+  public void dismiss() {
+    finish();
+  }
+
+  public boolean saveDocument() throws IOException {
+    final PdfDocument document = getDocument();
+    if (document != null) {
+      return document.saveIfModified();
+    } else {
+      return false;
     }
+  }
 }

--- a/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
+++ b/src/android/java/com/pspdfkit/cordova/PSPDFKitCordovaPlugin.java
@@ -23,6 +23,8 @@ import com.pspdfkit.cordova.action.annotation.GetAnnotationsAction;
 import com.pspdfkit.cordova.action.document.SaveDocumentAction;
 import com.pspdfkit.cordova.action.document.ShowDocumentFromAssetsAction;
 import com.pspdfkit.cordova.action.document.ShowDocumentAction;
+import com.pspdfkit.cordova.action.xfdf.ExportXfdfAction;
+import com.pspdfkit.cordova.action.xfdf.ImportXfdfAction;
 import com.pspdfkit.cordova.event.EventDispatcher;
 
 import org.apache.cordova.CallbackContext;
@@ -71,7 +73,10 @@ public class PSPDFKitCordovaPlugin extends CordovaPlugin {
             new AddAnnotationAction("addAnnotation", this),
             new ApplyInstantJsonAction("applyInstantJson", this),
             new GetAnnotationsAction("getAnnotations", this),
-            new GetAllUnsavedAnnotationsAction("getAllUnsavedAnnotations", this));
+            new GetAllUnsavedAnnotationsAction("getAllUnsavedAnnotations", this),
+            new ImportXfdfAction("importXfdf", this),
+            new ExportXfdfAction("exportXfdf", this)
+        );
   }
 
   private void initializePSPDFKit(CordovaInterface cordova) {

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/ApplyInstantJsonAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/ApplyInstantJsonAction.java
@@ -16,8 +16,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.IOException;
-
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
@@ -35,7 +33,8 @@ public class ApplyInstantJsonAction extends BasicAction {
   @Override
   protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
     JSONObject annotationsJson = args.getJSONObject(ARG_ANNOTATIONS_JSON);
-    final PdfDocument document = CordovaPdfActivity.getCurrentActivity().getDocument();
+    CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
+    final PdfDocument document = cordovaPdfActivity.getDocument();
 
     // Capture the given callback and make sure it is retained in JavaScript too.
     final PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
@@ -44,11 +43,13 @@ public class ApplyInstantJsonAction extends BasicAction {
 
     if (document != null) {
       final DataProvider dataProvider = new DocumentJsonDataProvider(annotationsJson);
-      DocumentJsonFormatter.importDocumentJsonAsync(document, dataProvider)
-          .subscribeOn(Schedulers.io())
-          .observeOn(AndroidSchedulers.mainThread())
-          .doOnError(e -> callbackContext.error(e.getMessage()))
-          .subscribe(() -> callbackContext.success());
+      cordovaPdfActivity.addSubscription(
+          DocumentJsonFormatter.importDocumentJsonAsync(document, dataProvider)
+              .subscribeOn(Schedulers.io())
+              .observeOn(AndroidSchedulers.mainThread())
+              .doOnError(e -> callbackContext.error(e.getMessage()))
+              .subscribe(() -> callbackContext.success())
+      );
     } else {
       callbackContext.error("No document is set");
     }

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/ApplyInstantJsonAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/ApplyInstantJsonAction.java
@@ -48,7 +48,7 @@ public class ApplyInstantJsonAction extends BasicAction {
               .subscribeOn(Schedulers.io())
               .observeOn(AndroidSchedulers.mainThread())
               .doOnError(e -> callbackContext.error(e.getMessage()))
-              .subscribe(() -> callbackContext.success())
+              .subscribe(callbackContext::success)
       );
     } else {
       callbackContext.error("No document is set");

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/ApplyInstantJsonAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/ApplyInstantJsonAction.java
@@ -33,7 +33,7 @@ public class ApplyInstantJsonAction extends BasicAction {
   @Override
   protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
     JSONObject annotationsJson = args.getJSONObject(ARG_ANNOTATIONS_JSON);
-    CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
+    final CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
     final PdfDocument document = cordovaPdfActivity.getDocument();
 
     // Capture the given callback and make sure it is retained in JavaScript too.

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/GetAllUnsavedAnnotationsAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/GetAllUnsavedAnnotationsAction.java
@@ -30,7 +30,7 @@ public class GetAllUnsavedAnnotationsAction extends BasicAction {
 
   @Override
   protected void execAction(JSONArray args, CallbackContext callbackContext) {
-    CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
+    final CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
     final PdfDocument document = cordovaPdfActivity.getDocument();
     // Capture the given callback and make sure it is retained in JavaScript too.
     final PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/GetAllUnsavedAnnotationsAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/GetAllUnsavedAnnotationsAction.java
@@ -30,7 +30,8 @@ public class GetAllUnsavedAnnotationsAction extends BasicAction {
 
   @Override
   protected void execAction(JSONArray args, CallbackContext callbackContext) {
-    final PdfDocument document = CordovaPdfActivity.getCurrentActivity().getDocument();
+    CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
+    final PdfDocument document = cordovaPdfActivity.getDocument();
     // Capture the given callback and make sure it is retained in JavaScript too.
     final PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
     result.setKeepCallback(true);
@@ -38,14 +39,15 @@ public class GetAllUnsavedAnnotationsAction extends BasicAction {
 
     if (document != null) {
       final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-      DocumentJsonFormatter.exportDocumentJsonAsync(document, outputStream)
+      cordovaPdfActivity.addSubscription(DocumentJsonFormatter.exportDocumentJsonAsync(document, outputStream)
           .subscribeOn(Schedulers.io())
           .observeOn(AndroidSchedulers.mainThread())
           .doOnError(e -> callbackContext.error(e.getMessage()))
           .subscribe(() -> {
             JSONObject response = new JSONObject(outputStream.toString());
             callbackContext.success(response);
-          });
+          })
+      );
     } else {
       callbackContext.error("No document is set");
     }

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java
@@ -50,9 +50,9 @@ public class GetAnnotationsAction extends BasicAction {
               getTypeFromString(convertJsonNullToJavaNull(args.getString(ARG_ANNOTATION_TYPE))),
               args.getInt(ARG_PAGE_INDEX),
               1)
+              .observeOn(Schedulers.io())
               .map(Annotation::toInstantJson)
               .toList()
-              .subscribeOn(Schedulers.io())
               .observeOn(AndroidSchedulers.mainThread())
               .doOnError(e -> callbackContext.error(e.getMessage()))
               .subscribe(strings -> {

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java
@@ -33,7 +33,7 @@ public class GetAnnotationsAction extends BasicAction {
 
   @Override
   protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
-    CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
+    final CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
     final PdfDocument document = cordovaPdfActivity.getDocument();
 
     // Capture the given callback and make sure it is retained in JavaScript too.

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/GetAnnotationsAction.java
@@ -36,7 +36,8 @@ public class GetAnnotationsAction extends BasicAction {
 
   @Override
   protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
-    final PdfDocument document = CordovaPdfActivity.getCurrentActivity().getDocument();
+    CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
+    final PdfDocument document = cordovaPdfActivity.getDocument();
 
     // Capture the given callback and make sure it is retained in JavaScript too.
     final PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
@@ -44,19 +45,21 @@ public class GetAnnotationsAction extends BasicAction {
     callbackContext.sendPluginResult(result);
 
     if (document != null) {
-      document.getAnnotationProvider().getAllAnnotationsOfType(
-          getTypeFromString(convertJsonNullToJavaNull(args.getString(ARG_ANNOTATION_TYPE))),
-          args.getInt(ARG_PAGE_INDEX),
-          1)
-          .map(Annotation::toInstantJson)
-          .toList()
-          .subscribeOn(Schedulers.io())
-          .observeOn(AndroidSchedulers.mainThread())
-          .doOnError(e -> callbackContext.error(e.getMessage()))
-          .subscribe(strings -> {
-            JSONArray response = new JSONArray(strings);
-            callbackContext.success(response);
-          });
+      cordovaPdfActivity.addSubscription(
+          document.getAnnotationProvider().getAllAnnotationsOfType(
+              getTypeFromString(convertJsonNullToJavaNull(args.getString(ARG_ANNOTATION_TYPE))),
+              args.getInt(ARG_PAGE_INDEX),
+              1)
+              .map(Annotation::toInstantJson)
+              .toList()
+              .subscribeOn(Schedulers.io())
+              .observeOn(AndroidSchedulers.mainThread())
+              .doOnError(e -> callbackContext.error(e.getMessage()))
+              .subscribe(strings -> {
+                JSONArray response = new JSONArray(strings);
+                callbackContext.success(response);
+              })
+      );
     } else {
       callbackContext.error("No document is set");
     }

--- a/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/annotation/RemoveAnnotationAction.java
@@ -51,9 +51,12 @@ public class RemoveAnnotationAction extends BasicAction {
     final PdfDocument document = pdfActivity.getDocument();
     if (document != null) {
       AnnotationProvider annotationProvider = document.getAnnotationProvider();
-      annotationProvider.getAllAnnotationsOfType(getAnnotationTypeFromString(type), pageIndex, 1)
+      pdfActivity.addSubscription(annotationProvider.getAllAnnotationsOfType(
+          getAnnotationTypeFromString(type),
+          pageIndex,
+          1)
+          .observeOn(Schedulers.io())
           .filter(annotationToFilter -> !name.isEmpty() && name.equals(annotationToFilter.getName()))
-          .subscribeOn(Schedulers.io())
           .observeOn(AndroidSchedulers.mainThread())
           .doOnError(e -> callbackContext.error(e.getMessage()))
           .subscribe(annotation -> {
@@ -65,7 +68,8 @@ public class RemoveAnnotationAction extends BasicAction {
             }
 
             callbackContext.success();
-          });
+          })
+      );
     } else {
       callbackContext.error("No document is set");
     }

--- a/src/android/java/com/pspdfkit/cordova/action/xfdf/ExportXfdfAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/xfdf/ExportXfdfAction.java
@@ -1,19 +1,16 @@
 package com.pspdfkit.cordova.action.xfdf;
 
 import android.net.Uri;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
-import com.pspdfkit.annotations.Annotation;
+import com.pspdfkit.annotations.AnnotationType;
 import com.pspdfkit.cordova.CordovaPdfActivity;
 import com.pspdfkit.cordova.PSPDFKitCordovaPlugin;
 import com.pspdfkit.cordova.action.BasicAction;
 import com.pspdfkit.document.PdfDocument;
 import com.pspdfkit.document.formatters.XfdfFormatter;
-import com.pspdfkit.document.providers.ContentResolverDataProvider;
 import com.pspdfkit.forms.FormField;
-import com.pspdfkit.ui.PdfFragment;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;
@@ -23,9 +20,8 @@ import org.json.JSONException;
 import java.io.FileNotFoundException;
 import java.io.OutputStream;
 import java.util.Collections;
-import java.util.List;
+import java.util.EnumSet;
 
-import io.reactivex.Completable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
@@ -46,7 +42,6 @@ public class ExportXfdfAction extends BasicAction {
 
     final CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
     final PdfDocument document = cordovaPdfActivity.getDocument();
-    final PdfFragment pdfFragment = cordovaPdfActivity.getPdfFragment();
 
     // Capture the given callback and make sure it is retained in JavaScript too.
     final PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
@@ -54,53 +49,31 @@ public class ExportXfdfAction extends BasicAction {
     callbackContext.sendPluginResult(result);
 
     if (document != null) {
-      cordovaPdfActivity.addSubscription(
-          XfdfFormatter.parseXfdfAsync(document, new ContentResolverDataProvider(xfdfFileUri))
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .doOnError(e -> callbackContext.error(e.getMessage()))
-              .subscribe(annotations -> {
-                if (pdfFragment != null) {
-                  // Annotations parsed from XFDF are not added to document automatically. We need to add them manually.
-                  for (Annotation annotation : annotations) {
-                    pdfFragment.addAnnotationToPage(annotation, false);
-                  }
+      try {
+        final OutputStream outputStream = cordovaPdfActivity.getContentResolver().openOutputStream(xfdfFileUri);
+        if (outputStream == null) {
+          callbackContext.error("Failed to open output stream during XFDF export");
+          return;
+        }
 
-                  callbackContext.success();
-                } else {
-                  callbackContext.error("PdfFragment is null");
-                }
-
-              })
-      );
+        cordovaPdfActivity.addSubscription(document.getAnnotationProvider().getAllAnnotationsOfType(EnumSet.allOf(AnnotationType.class))
+            .toList()
+            .flatMapCompletable(annotations -> XfdfFormatter.writeXfdfAsync(
+                document,
+                annotations,
+                Collections.<FormField>emptyList(),
+                outputStream
+            )).doFinally(outputStream::close)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .doOnError(e -> callbackContext.error(e.getMessage()))
+            .subscribe(callbackContext::success)
+        );
+      } catch (FileNotFoundException exception) {
+        callbackContext.error(exception.getMessage());
+      }
     } else {
       callbackContext.error("No document is set");
-    }
-
-    //////////////////////
-    try {
-      final OutputStream outputStream = cordovaPdfActivity.getContentResolver().openOutputStream(xfdfFileUri);
-      if (outputStream == null) return;
-
-      List<Annotation> documentAnnotations = Collections.emptyList();
-      for (int i = 0, n = document.getPageCount(); i < n; i++) {
-        final List<Annotation> pageAnnotations = document.getAnnotationProvider().getAnnotations(i);
-        if (!pageAnnotations.isEmpty()) {
-          documentAnnotations.addAll(pageAnnotations);
-        }
-      }
-
-      Completable writeXfdfCompletable = XfdfFormatter.writeXfdfAsync(
-          document,
-          documentAnnotations,
-          Collections.<FormField>emptyList(),
-          outputStream
-      );
-      writeXfdfCompletable
-          .observeOn(AndroidSchedulers.mainThread())
-          .doFinally(outputStream::close)
-          .subscribe();
-    } catch (FileNotFoundException ignored) {
     }
   }
 }

--- a/src/android/java/com/pspdfkit/cordova/action/xfdf/ExportXfdfAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/xfdf/ExportXfdfAction.java
@@ -1,0 +1,56 @@
+package com.pspdfkit.cordova.action.xfdf;
+
+import androidx.annotation.NonNull;
+
+import com.pspdfkit.cordova.CordovaPdfActivity;
+import com.pspdfkit.cordova.PSPDFKitCordovaPlugin;
+import com.pspdfkit.cordova.action.BasicAction;
+import com.pspdfkit.cordova.provider.DocumentJsonDataProvider;
+import com.pspdfkit.document.PdfDocument;
+import com.pspdfkit.document.formatters.DocumentJsonFormatter;
+import com.pspdfkit.document.providers.DataProvider;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Asynchronously imports a document JSON and applies its changes to the document.
+ */
+public class ExportXfdfAction extends BasicAction {
+
+  private static final int ARG_ANNOTATIONS_JSON = 0;
+
+  public ExportXfdfAction(@NonNull String name, @NonNull PSPDFKitCordovaPlugin plugin) {
+    super(name, plugin);
+  }
+
+  @Override
+  protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
+    JSONObject annotationsJson = args.getJSONObject(ARG_ANNOTATIONS_JSON);
+    final PdfDocument document = CordovaPdfActivity.getCurrentActivity().getDocument();
+
+    // Capture the given callback and make sure it is retained in JavaScript too.
+    final PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
+    result.setKeepCallback(true);
+    callbackContext.sendPluginResult(result);
+
+    if (document != null) {
+      final DataProvider dataProvider = new DocumentJsonDataProvider(annotationsJson);
+      DocumentJsonFormatter.importDocumentJsonAsync(document, dataProvider)
+          .subscribeOn(Schedulers.io())
+          .observeOn(AndroidSchedulers.mainThread())
+          .doOnError(e -> callbackContext.error(e.getMessage()))
+          .subscribe(() -> callbackContext.success());
+    } else {
+      callbackContext.error("No document is set");
+    }
+  }
+}

--- a/src/android/java/com/pspdfkit/cordova/action/xfdf/ExportXfdfAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/xfdf/ExportXfdfAction.java
@@ -26,7 +26,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
 /**
- * Asynchronously imports a document JSON and applies its changes to the document.
+ * Asynchronously exports annotations to XFDF-file from the current document.
  */
 public class ExportXfdfAction extends BasicAction {
 
@@ -58,13 +58,13 @@ public class ExportXfdfAction extends BasicAction {
 
         cordovaPdfActivity.addSubscription(document.getAnnotationProvider().getAllAnnotationsOfType(EnumSet.allOf(AnnotationType.class))
             .toList()
+            .observeOn(Schedulers.io())
             .flatMapCompletable(annotations -> XfdfFormatter.writeXfdfAsync(
                 document,
                 annotations,
                 Collections.<FormField>emptyList(),
                 outputStream
             )).doFinally(outputStream::close)
-            .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .doOnError(e -> callbackContext.error(e.getMessage()))
             .subscribe(callbackContext::success)

--- a/src/android/java/com/pspdfkit/cordova/action/xfdf/ImportXfdfAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/xfdf/ImportXfdfAction.java
@@ -1,0 +1,56 @@
+package com.pspdfkit.cordova.action.xfdf;
+
+import androidx.annotation.NonNull;
+
+import com.pspdfkit.cordova.CordovaPdfActivity;
+import com.pspdfkit.cordova.PSPDFKitCordovaPlugin;
+import com.pspdfkit.cordova.action.BasicAction;
+import com.pspdfkit.cordova.provider.DocumentJsonDataProvider;
+import com.pspdfkit.document.PdfDocument;
+import com.pspdfkit.document.formatters.DocumentJsonFormatter;
+import com.pspdfkit.document.providers.DataProvider;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Asynchronously imports a document JSON and applies its changes to the document.
+ */
+public class ImportXfdfAction extends BasicAction {
+
+  private static final int ARG_ANNOTATIONS_JSON = 0;
+
+  public ImportXfdfAction(@NonNull String name, @NonNull PSPDFKitCordovaPlugin plugin) {
+    super(name, plugin);
+  }
+
+  @Override
+  protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
+    JSONObject annotationsJson = args.getJSONObject(ARG_ANNOTATIONS_JSON);
+    final PdfDocument document = CordovaPdfActivity.getCurrentActivity().getDocument();
+
+    // Capture the given callback and make sure it is retained in JavaScript too.
+    final PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
+    result.setKeepCallback(true);
+    callbackContext.sendPluginResult(result);
+
+    if (document != null) {
+      final DataProvider dataProvider = new DocumentJsonDataProvider(annotationsJson);
+      DocumentJsonFormatter.importDocumentJsonAsync(document, dataProvider)
+          .subscribeOn(Schedulers.io())
+          .observeOn(AndroidSchedulers.mainThread())
+          .doOnError(e -> callbackContext.error(e.getMessage()))
+          .subscribe(() -> callbackContext.success());
+    } else {
+      callbackContext.error("No document is set");
+    }
+  }
+}

--- a/src/android/java/com/pspdfkit/cordova/action/xfdf/ImportXfdfAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/xfdf/ImportXfdfAction.java
@@ -48,6 +48,7 @@ public class ImportXfdfAction extends BasicAction {
     if (document != null) {
       cordovaPdfActivity.addSubscription(
           XfdfFormatter.parseXfdfAsync(document, new ContentResolverDataProvider(xfdfFileUri))
+              .subscribeOn(Schedulers.io())
               .map(annotations -> {
                 if (pdfFragment != null) {
                   // Annotations parsed from XFDF are not added to document automatically. We need to add them manually.
@@ -60,7 +61,6 @@ public class ImportXfdfAction extends BasicAction {
                   return false;
                 }
               })
-              .subscribeOn(Schedulers.io())
               .observeOn(AndroidSchedulers.mainThread())
               .doOnError(e -> callbackContext.error(e.getMessage()))
               .subscribe(success -> {

--- a/src/android/java/com/pspdfkit/cordova/action/xfdf/ImportXfdfAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/xfdf/ImportXfdfAction.java
@@ -1,22 +1,22 @@
 package com.pspdfkit.cordova.action.xfdf;
 
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 
+import com.pspdfkit.annotations.Annotation;
 import com.pspdfkit.cordova.CordovaPdfActivity;
 import com.pspdfkit.cordova.PSPDFKitCordovaPlugin;
 import com.pspdfkit.cordova.action.BasicAction;
-import com.pspdfkit.cordova.provider.DocumentJsonDataProvider;
 import com.pspdfkit.document.PdfDocument;
-import com.pspdfkit.document.formatters.DocumentJsonFormatter;
-import com.pspdfkit.document.providers.DataProvider;
+import com.pspdfkit.document.formatters.XfdfFormatter;
+import com.pspdfkit.document.providers.ContentResolverDataProvider;
+import com.pspdfkit.ui.PdfFragment;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.io.IOException;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
@@ -26,7 +26,7 @@ import io.reactivex.schedulers.Schedulers;
  */
 public class ImportXfdfAction extends BasicAction {
 
-  private static final int ARG_ANNOTATIONS_JSON = 0;
+  private static final int ARG_XFDF_FILE_URI = 0;
 
   public ImportXfdfAction(@NonNull String name, @NonNull PSPDFKitCordovaPlugin plugin) {
     super(name, plugin);
@@ -34,8 +34,11 @@ public class ImportXfdfAction extends BasicAction {
 
   @Override
   protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
-    JSONObject annotationsJson = args.getJSONObject(ARG_ANNOTATIONS_JSON);
-    final PdfDocument document = CordovaPdfActivity.getCurrentActivity().getDocument();
+    final Uri xfdfFileUri = Uri.parse(args.getString(ARG_XFDF_FILE_URI));
+
+    final CordovaPdfActivity cordovaPdfActivity = CordovaPdfActivity.getCurrentActivity();
+    final PdfDocument document = cordovaPdfActivity.getDocument();
+    final PdfFragment pdfFragment = cordovaPdfActivity.getPdfFragment();
 
     // Capture the given callback and make sure it is retained in JavaScript too.
     final PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
@@ -43,12 +46,25 @@ public class ImportXfdfAction extends BasicAction {
     callbackContext.sendPluginResult(result);
 
     if (document != null) {
-      final DataProvider dataProvider = new DocumentJsonDataProvider(annotationsJson);
-      DocumentJsonFormatter.importDocumentJsonAsync(document, dataProvider)
-          .subscribeOn(Schedulers.io())
-          .observeOn(AndroidSchedulers.mainThread())
-          .doOnError(e -> callbackContext.error(e.getMessage()))
-          .subscribe(() -> callbackContext.success());
+      cordovaPdfActivity.addSubscription(
+          XfdfFormatter.parseXfdfAsync(document, new ContentResolverDataProvider(xfdfFileUri))
+              .subscribeOn(Schedulers.io())
+              .observeOn(AndroidSchedulers.mainThread())
+              .doOnError(e -> callbackContext.error(e.getMessage()))
+              .subscribe(annotations -> {
+                if (pdfFragment != null) {
+                  // Annotations parsed from XFDF are not added to document automatically. We need to add them manually.
+                  for (Annotation annotation : annotations) {
+                    pdfFragment.addAnnotationToPage(annotation, false);
+                  }
+
+                  callbackContext.success();
+                } else {
+                  callbackContext.error("PdfFragment is null");
+                }
+
+              })
+      );
     } else {
       callbackContext.error("No document is set");
     }

--- a/src/android/java/com/pspdfkit/cordova/action/xfdf/ImportXfdfAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/xfdf/ImportXfdfAction.java
@@ -1,6 +1,7 @@
 package com.pspdfkit.cordova.action.xfdf;
 
 import android.net.Uri;
+import android.os.Environment;
 
 import androidx.annotation.NonNull;
 
@@ -17,6 +18,9 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
+
+import java.io.File;
+import java.net.URI;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;

--- a/www/PSPDFKit.js
+++ b/www/PSPDFKit.js
@@ -197,7 +197,7 @@ exports.saveDocument = function(success, error) {
  * @param error Error callback function
  */
 exports.importXfdf = function(xfdfFile, success, error) {
-  exec(success, error, "PSPDFKitCordovaPlugin", "importXfdf");
+  exec(success, error, "PSPDFKitCordovaPlugin", "importXfdf", [xfdfFile]);
 };
 
 /**
@@ -208,7 +208,7 @@ exports.importXfdf = function(xfdfFile, success, error) {
  * @param error Error callback function
  */
 exports.exportXfdf = function(xfdfFile, success, error) {
-  exec(success, error, "PSPDFKitCordovaPlugin", "exportXfdf");
+  exec(success, error, "PSPDFKitCordovaPlugin", "exportXfdf", [xfdfFile]);
 };
 
 /**

--- a/www/PSPDFKit.js
+++ b/www/PSPDFKit.js
@@ -191,7 +191,8 @@ exports.saveDocument = function(success, error) {
 
 /**
  * Imports all annotations from the specified XFDF file to the current document.
- *
+ * 
+ * @param xfdfFile XFDF file URI to import annotations to
  * @param success Success callback function.
  * @param error Error callback function
  */
@@ -201,7 +202,8 @@ exports.importXfdf = function(xfdfFile, success, error) {
 
 /**
  * Exports all annotations from the current document to the specified XFDF file path.
- *
+ * 
+ * @param xfdfFile XFDF file URI to export annotations from
  * @param success Success callback function.
  * @param error Error callback function
  */

--- a/www/PSPDFKit.js
+++ b/www/PSPDFKit.js
@@ -190,6 +190,26 @@ exports.saveDocument = function(success, error) {
 };
 
 /**
+ * Imports all annotations from the specified XFDF file to the current document.
+ *
+ * @param success Success callback function.
+ * @param error Error callback function
+ */
+exports.importXfdf = function(xfdfFile, success, error) {
+  exec(success, error, "PSPDFKitCordovaPlugin", "importXfdf");
+};
+
+/**
+ * Exports all annotations from the current document to the specified XFDF file path.
+ *
+ * @param success Success callback function.
+ * @param error Error callback function
+ */
+exports.exportXfdf = function(xfdfFile, success, error) {
+  exec(success, error, "PSPDFKitCordovaPlugin", "exportXfdf");
+};
+
+/**
  * Constant values used for setting the `scrollMode` option.
  */
 exports.ScrollMode = {


### PR DESCRIPTION
Adds:
- `importXfdf` - imports all annotations from the specified XFDF file to the current document.
- `exportXfdf` - exports all annotations from the current document to the specified XFDF file.
- collection of disposables to track reactive subscriptions