### PR TITLE
Fix save callback after activity onDestroy

### DIFF
--- a/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
+++ b/src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java
@@ -1,6 +1,7 @@
 package com.pspdfkit.cordova;
 
 import android.os.Bundle;
+import android.util.Log;
 
 import com.pspdfkit.cordova.event.EventDispatcher;
 import com.pspdfkit.document.PdfDocument;
@@ -21,6 +22,8 @@ import io.reactivex.disposables.Disposable;
 import static com.pspdfkit.cordova.Utilities.checkArgumentNotNull;
 
 public class CordovaPdfActivity extends PdfActivity {
+
+  public static final String LOG_TAG = "CordovaPdfActivity";
 
   /**
    * For communication with the JavaScript context, we keep a static reference to the current
@@ -45,7 +48,7 @@ public class CordovaPdfActivity extends PdfActivity {
         data.put("message", exception.getMessage());
         EventDispatcher.getInstance().sendEvent("onDocumentSaveFailed", data);
       } catch (JSONException e) {
-        e.printStackTrace();
+        Log.e(LOG_TAG, "Error while creating JSON payload for 'onDocumentSaveFailed' event.", e);
       }
     }
   };


### PR DESCRIPTION
This PR fixes an issue, where the `onDocumentSaved` event would not be dispatched in JavaScript when saving of a document was completed after `onDestroy()` of the activity was called.

The solution was to extend the lifetime of the `DocumentListener` inside `CordovaPdfActivity` to outlive the activity lifecycle. Since we offer a static JavaScript API interface, I also opted for a static listener instance (i.e. singleton listener) that is reused between activities. This is possible, since the current `DocumentListener` is only a delegate to JavaScript, and does not carry any internal state.